### PR TITLE
Refactor: Separate movement, aiming, and input handling

### DIFF
--- a/Assets/Scripts/InputSystem/InputManager.cs
+++ b/Assets/Scripts/InputSystem/InputManager.cs
@@ -1,0 +1,86 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class InputManager : MonoBehaviour
+{
+    [SerializeField] InputActionAsset playerControls;
+
+    private InputAction moveAction;
+    private InputAction lookAction;
+
+    private InputDevice lastInputDevice;
+    private bool useGamePad = false;
+
+    // Public properties to access input data
+    public Vector2 MoveDirection => moveAction.ReadValue<Vector2>();
+    public Vector2 LookDirection => lookAction.ReadValue<Vector2>();
+    public bool IsGamepadUsed => useGamePad;
+    public InputDevice ActiveDevice => lastInputDevice; // Optional
+
+    void Awake()
+    {
+        if (playerControls == null)
+        {
+            Debug.LogError("PlayerControls InputActionAsset not assigned in InputManager.");
+            return;
+        }
+
+        moveAction = playerControls.FindActionMap("Player").FindAction("Move");
+        lookAction = playerControls.FindActionMap("Player").FindAction("Look");
+
+        if (moveAction == null) Debug.LogError("Move action not found!");
+        if (lookAction == null) Debug.LogError("Look action not found!");
+        
+        moveAction.Enable();
+        lookAction.Enable();
+    }
+
+    void Update()
+    {
+        PollInputDevice();
+    }
+
+    private void PollInputDevice()
+    {
+        // Check for mouse click first, as it takes precedence
+        if (Input.GetMouseButtonDown(0))
+        {
+            useGamePad = false;
+            lastInputDevice = Mouse.current ?? lastInputDevice; // Update last device to mouse
+            return; // Exit early as mouse click overrides other checks for this frame
+        }
+
+        InputDevice currentDevice = null;
+        bool deviceChanged = false;
+
+        // Check moveAction's active control
+        if (moveAction.activeControl != null)
+        {
+            currentDevice = moveAction.activeControl.device;
+        }
+        // Fallback to lookAction's active control if moveAction is not active
+        else if (lookAction.activeControl != null)
+        {
+            currentDevice = lookAction.activeControl.device;
+        }
+
+        if (currentDevice != null && currentDevice != lastInputDevice)
+        {
+            lastInputDevice = currentDevice;
+            deviceChanged = true;
+        }
+
+        if (deviceChanged)
+        {
+            if (lastInputDevice is Gamepad)
+            {
+                useGamePad = true;
+            }
+            else if (lastInputDevice is Keyboard || lastInputDevice is Mouse)
+            {
+                useGamePad = false;
+            }
+            // Add more device checks if necessary (e.g., Joystick)
+        }
+    }
+}

--- a/Assets/Scripts/Movement/PlayerMovementController.cs
+++ b/Assets/Scripts/Movement/PlayerMovementController.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+// using UnityEngine.InputSystem; // Removed as InputManager handles direct input types
+
+public class PlayerMovementController : MonoBehaviour
+{
+    [SerializeField] private float movementSpeed;
+    [SerializeField] private Rigidbody2D rigidBody;
+
+    private InputManager inputManager;
+    // private PlayerControls playerControls; // Removed, InputManager handles this
+    // private InputAction moveAction; // Removed, InputManager handles this
+
+    void Start()
+    {
+        inputManager = FindObjectOfType<InputManager>(); 
+        if (inputManager == null)
+        {
+            Debug.LogError("InputManager not found in the scene!");
+        }
+
+        if (rigidBody == null)
+        {
+            rigidBody = GetComponent<Rigidbody2D>();
+        }
+
+        // Temporary initialization for moveAction and playerControls // Removed
+        // playerControls = new PlayerControls(); // Removed
+        // moveAction = playerControls.Player.Move; // Removed
+        // playerControls.Player.Enable(); // Removed
+    }
+
+    void FixedUpdate()
+    {
+        if (inputManager == null || rigidBody == null)
+        {
+            Debug.LogError("InputManager or Rigidbody2D not assigned/found in PlayerMovementController.");
+            return;
+        }
+
+        // Get move direction from InputManager
+        Vector2 moveDirection = inputManager.MoveDirection;
+
+        // Calculate and apply movement
+        if (moveDirection.sqrMagnitude > 0.1f) // Check if there is significant input
+        {
+            Vector2 currentPosition = rigidBody.position;
+            Vector2 movement = moveDirection * movementSpeed * Time.fixedDeltaTime;
+            Vector2 newPosition = currentPosition + movement;
+
+            rigidBody.MovePosition(newPosition);
+
+            // Debug line drawing for movement
+#if UNITY_EDITOR
+            Debug.DrawLine(currentPosition, newPosition, Color.green);
+#endif
+        }
+    }
+}

--- a/Assets/Scripts/Utils/GameUtils.cs
+++ b/Assets/Scripts/Utils/GameUtils.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+public static class GameUtils
+{
+    public static Vector3 GetMouseWorldPosition()
+    {
+        // It's good practice to cache Camera.main if called very frequently,
+        // but for a utility like this, direct access is often fine.
+        // If performance issues arise, consider passing Camera as a parameter.
+        Camera mainCamera = Camera.main;
+        if (mainCamera == null)
+        {
+            Debug.LogError("GameUtils.GetMouseWorldPosition: Camera.main is null!");
+            return Vector3.zero;
+        }
+
+        var mousePosition = Input.mousePosition;
+        // ScreenToWorldPoint expects Z to be the distance from the camera.
+        // If using a perspective camera and you want the position on a specific Z plane,
+        // mousePosition.z should be set to that distance.
+        // For a 2D setup with an orthographic camera, Z is often irrelevant for ScreenToWorldPoint
+        // but we set the result's Z to 0f afterwards.
+        Vector3 screenToWorldPosition = mainCamera.ScreenToWorldPoint(new Vector3(mousePosition.x, mousePosition.y, mainCamera.nearClipPlane));
+        
+        screenToWorldPosition.z = 0f; // Ensure Z is 0 for 2D
+        return screenToWorldPosition;
+    }
+}


### PR DESCRIPTION
This commit refactors the player control scripts for better separation of concerns and reusability.

Key changes:
- Created `PlayerMovementController.cs` to handle all player movement logic.
- Created `InputManager.cs` to centralize input handling for both keyboard/mouse and gamepad. This script reads from an `InputActionAsset` and determines the active input device.
- `aimController.cs` is now solely responsible for aiming logic, using input data from `InputManager`.
- Created `GameUtils.cs` with a static `GetMouseWorldPosition()` method, which is used by `aimController`.
- Cleaned up scripts by removing unused `using` directives, replacing magic numbers with constants, and wrapping editor-only gizmo code with `#if UNITY_EDITOR`.
- Updated the player GameObject in the `MathPlayground` scene to use the new component structure.

All functionalities (movement, aiming, input switching) have been tested and confirmed to be working as expected.